### PR TITLE
Use udev uaccess tag instead of world-writable

### DIFF
--- a/u2f/README.md
+++ b/u2f/README.md
@@ -78,12 +78,10 @@ already) to reflect the new product and vendor IDs so that you'll have
 permissions to the device.
 
 ```
-ATTRS{idProduct}=="cdab", ATTRS{idVendor}=="0483", MODE="777"
+ACTION=="add|change", KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="cdab", TAG+="uaccess"
 ```
 
-(Note: you can give it a more restrictive mode if you also give it a
-`GROUP` that you're in; if you are on a multi-user system you should
-not set the `MODE` to 777.)
+Ubuntu before 13.04 Raring will need the `udev-acl` tag rather than `uaccess`.
 
 ### Readout protection
 


### PR DESCRIPTION
Recommending that your U2F devices should be world-writable is probably a _really_ bad idea.

This changes that recommendation to use the systemd-udevd uaccess tag instead, which will allow users with currently logged-in sessions to access the device.

Based on udev rules Yubico distribute [in libu2f-host](https://github.com/Yubico/libu2f-host/blob/master/70-u2f.rules).