### PR TITLE
Readout protection should be enabled by default for added security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - 'cd u2f'
   - 'make'
   - 'make clean certclean'
-  - 'make ENFORCE_DEBUG_LOCK=1'
+  - 'make'
   - 'openssl ecparam -name prime256v1 -genkey -noout -outform der -out key.der'
   - './inject_key.py --key key.der --ctr 1001'
   - 'cd ..'

--- a/u2f/Makefile
+++ b/u2f/Makefile
@@ -14,6 +14,7 @@ USE_SYS = yes
 USE_USB = yes
 USE_ADC = yes
 USE_EVENTFLAG = yes
+ENFORCE_DEBUG_LOCK = 1
 
 ###################################
 CROSS = arm-none-eabi-

--- a/u2f/README.md
+++ b/u2f/README.md
@@ -85,12 +85,12 @@ Ubuntu before 13.04 Raring will need the `udev-acl` tag rather than `uaccess`.
 
 ### Readout protection
 
-Make sure to enable readout protection if you are going to use Tomu as 2FA for
-your accounts. Build firmware with `ENFORCE_DEBUG_LOCK=1`:
+Readout protection is enabled by default. To disable it, build firmware with
+`ENFORCE_DEBUG_LOCK=0`:
 
 ``` sh
 make clean
-make ENFORCE_DEBUG_LOCK=1
+make ENFORCE_DEBUG_LOCK=0
 ```
 
 


### PR DESCRIPTION
When I first flashed my Tomu, I went over the instructions quickly and didn't see the part about the readout protection.

I think having it on by default makes for more secure defaults and will help others not to make the mistake I made by inadvertence.