### PR TITLE
Doc Enhancement: Update asn1crypto instructions

### DIFF
--- a/u2f/README.md
+++ b/u2f/README.md
@@ -54,6 +54,8 @@ To install with pip:
 pip install --user --upgrade asn1crypto
 ```
 
+*If you were trigger happy and tried to run ```make``` before you installed this package, you will need to run the command* ```make certclean``` *then install the package, and finally run ```make``` again.*
+
 ### Building
 
 ``` sh


### PR DESCRIPTION
Recommend adding the following text to the U2F instruction README.md

> *If you were trigger happy and tried to run ```make``` before you installed this package, you will need to run the command* ```make certclean``` *then install the package, and finally run ```make``` again.*


Ran in to this issue when trying to set up my Tomu. This issue is documented fully here [https://github.com/gl-sergei/u2f-token/issues/8#issue-324599672](https://github.com/gl-sergei/u2f-token/issues/8#issue-324599672)